### PR TITLE
feat: enable token authentication for REST framework

### DIFF
--- a/qcon/settings.py
+++ b/qcon/settings.py
@@ -278,7 +278,7 @@ REST_FRAMEWORK = {
         # 'rest_framework.permissions.IsAuthenticated',
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        # 'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
         # 'rest_framework.authentication.BasicAuthentication',
         # 'api_v2.authentication.ExampleAuthentication',
     ]


### PR DESCRIPTION
- Uncommented TokenAuthentication in DEFAULT_AUTHENTICATION_CLASSES
- Enables token-based authentication for API endpoints

Closes issue #19 
